### PR TITLE
Implementation of alpha's functionality in leakyRelu

### DIFF
--- a/MLlib/activations.py
+++ b/MLlib/activations.py
@@ -108,6 +108,8 @@ def leakyRelu(X):
 
     X: ndarray(dtype=float, ndim=1)
         Array containing Input Values.
+    alpha: float
+        Slope for Values of X less than 0.
 
     RETURNS
     =======

--- a/MLlib/activations.py
+++ b/MLlib/activations.py
@@ -99,7 +99,7 @@ def relu(X):
     return np.maximum(0, X)
 
 
-def leakyRelu(X):
+def leakyRelu(X, alpha=0.01):
     """
     Apply Leaky Rectified Linear Unit on X Vector.
 
@@ -117,7 +117,7 @@ def leakyRelu(X):
     ndarray(dtype=float,ndim=1)
         Output Vector after Vectorised Operation.
     """
-    return np.maximum(0.01*X, X)
+    return np.maximum(alpha*X, X)
 
 
 def elu(X, alpha=1.0):


### PR DESCRIPTION
closes #73 

leakyRelu activation function has been modified to accept alpha(slope of activation for X<0) as a parameter with its default value set to 0.01.
